### PR TITLE
Fix HTML attribute typos

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -43,7 +43,7 @@
 <link href='//pagead2.googlesyndication.com' rel='dns-prefetch'/>
 
 <link href='https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap' rel='stylesheet'/>
-<link rel='stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css'/>
+<link rel='stylesheet' href='https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css'/>
 <!-- Favicon -->
 <link href='https://cdn.jsdelivr.net/gh/bukitbesi/the@main/assets/favicon-image/favicon.ico' rel='icon' sizes='any'/>
 <link href='https://cdn.jsdelivr.net/gh/bukitbesi/the@main/assets/favicon-image/favicon.svg' rel='icon' type='image/svg+xml'/>
@@ -601,7 +601,7 @@ function removeHtmlTag(e,t){for(var s=e.split("<"),r=0;r<s.length;r++)-1!=s[r].i
 </script>
 <div class='ct-wrapper' id='feature-post-section'>
 <div class='featured-posts padding clearfix'>		
-<script type='text/javaScript'>
+<script type='text/javascript'>
 document.write("<script src=\"/feeds/posts/default/?max-results="+featured_numpost+"&orderby=published&alt=json-in-script&callback=sliderpost\"><\/script>");
 </script>							
 </div>


### PR DESCRIPTION
## Summary
- fix broken Font Awesome stylesheet tag
- standardize `text/javascript` attribute case

## Testing
- `npm test` *(fails: could not read package.json)*
- `npm run lint` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686d58ddf830832da495c3cbf9bfb979